### PR TITLE
Updated formattedTime to correct 12AM scenario

### DIFF
--- a/Adhan.js
+++ b/Adhan.js
@@ -782,6 +782,7 @@
             return hours + ':' + minutes;
         } else {
             hours = offset.getUTCHours() > 12 ? (offset.getUTCHours() - 12).toString() : offset.getUTCHours().toString();
+            hours = hours == 0 ? 12 : hours;
             minutes = offset.getUTCMinutes().toString();
             if (minutes.length < 2) {
                 minutes = '0' + minutes;


### PR DESCRIPTION
formattedTime was returning time in 0:MM format when time coincidentally happen to be between 12AM 12:59AM