### PR TITLE
Fixed latitude and longitude order for Coordinates constructor

### DIFF
--- a/Adhan.d.ts
+++ b/Adhan.d.ts
@@ -51,7 +51,7 @@ export namespace CalculationMethod {
 }
 
 export class Coordinates {
-  constructor(longitude: number, latitude: number);
+  constructor(latitude: number, longitude: number);
   longitude: number;
   latitude: number;
 }


### PR DESCRIPTION
In the source code, the constructor has latitude as the first argument and longitude as the second. The ts file had these two switched which gave incorrect hints in VS Code.