### PR TITLE
Fix release action

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -56,8 +56,7 @@ jobs:
     needs: Test
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           # latest nodejs LTS
@@ -82,8 +81,8 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
         with:
           # latest nodejs LTS
           node-version: 14.x


### PR DESCRIPTION
release action wasn't `use`ing node-setup, so npm install -g failed to update