### PR TITLE
test(audit): run audit with production flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "npm-run-all test:*",
     "test:lint": "eslint src/ test/",
     "test:unit": "jest",
-    "test:audit": "npm audit --audit-level=high",
+    "test:audit": "npm audit --production --audit-level=high",
     "test-watch": "jest --watch",
     "coverage": "codecov",
     "commit": "cz",


### PR DESCRIPTION
Changing the audit command to run
in production mode so devDependencies
aren't seen as vulnerabilities.