### PR TITLE
ci(commitlint): ignore release commits

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,6 @@
 module.exports = { 
   extends: ['@commitlint/config-conventional'],
+  ignores: [(message) => message.startsWith('chore(release)')],
   rules: {
     'footer-max-line-length': [0],
   }


### PR DESCRIPTION
Adds a rule to the commitlint config
to ignore linting for release commits