### PR TITLE
Fix backwards compatibility with commonjs

### DIFF
--- a/src/Adhan.ts
+++ b/src/Adhan.ts
@@ -11,7 +11,7 @@ import { Rounding } from './Rounding';
 import { Shafaq } from './Shafaq';
 import SunnahTimes from './SunnahTimes';
 
-const adhan = {
+export {
   Prayer,
   Madhab,
   HighLatitudeRule,
@@ -25,5 +25,3 @@ const adhan = {
   Rounding,
   Shafaq,
 };
-
-export default adhan;

--- a/test/adhan.test.ts
+++ b/test/adhan.test.ts
@@ -1,32 +1,36 @@
 /* eslint-disable max-lines */
-import adhan from '../src/Adhan';
 import moment from 'moment-timezone';
 import { dateByAddingSeconds, isValidDate } from '../src/DateUtils';
-import { shadowLength } from '../src/Madhab';
+import { Madhab, shadowLength } from '../src/Madhab';
 import * as polarCircleResolver from '../src/PolarCircleResolution';
 import { Shafaq } from '../src/Shafaq';
 import { ValueOf } from '../src/TypeUtils';
 import HighLatitudeRule from '../src/HighLatitudeRule';
+import CalculationMethod from '../src/CalculationMethod';
+import CalculationParameters from '../src/CalculationParameters';
+import Coordinates from '../src/Coordinates';
+import Prayer from '../src/Prayer';
+import PrayerTimes from '../src/PrayerTimes';
 
 test('Verifying the night portion defined by the high latitude rule', () => {
-  const p1 = new adhan.CalculationParameters('Other', 18, 18);
-  p1.highLatitudeRule = adhan.HighLatitudeRule.MiddleOfTheNight;
+  const p1 = new CalculationParameters('Other', 18, 18);
+  p1.highLatitudeRule = HighLatitudeRule.MiddleOfTheNight;
   expect(p1.nightPortions().fajr).toBe(0.5);
   expect(p1.nightPortions().isha).toBe(0.5);
 
-  const p2 = new adhan.CalculationParameters('Other', 18, 18);
-  p2.highLatitudeRule = adhan.HighLatitudeRule.SeventhOfTheNight;
+  const p2 = new CalculationParameters('Other', 18, 18);
+  p2.highLatitudeRule = HighLatitudeRule.SeventhOfTheNight;
   expect(p2.nightPortions().fajr).toBe(1 / 7);
   expect(p2.nightPortions().isha).toBe(1 / 7);
 
-  const p3 = new adhan.CalculationParameters('Other', 10, 15);
-  p3.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle;
+  const p3 = new CalculationParameters('Other', 10, 15);
+  p3.highLatitudeRule = HighLatitudeRule.TwilightAngle;
   expect(p3.nightPortions().fajr).toBe(10 / 60);
   expect(p3.nightPortions().isha).toBe(15 / 60);
 
-  const p4 = new adhan.CalculationParameters('Other', 10, 15);
+  const p4 = new CalculationParameters('Other', 10, 15);
   p4.highLatitudeRule = (
-    adhan.HighLatitudeRule as unknown as {
+    HighLatitudeRule as unknown as {
       fake: ValueOf<typeof HighLatitudeRule>;
     }
   ).fake;
@@ -39,85 +43,85 @@ test('Verifying the night portion defined by the high latitude rule', () => {
 });
 
 test('Verifying the angles defined by the calculation method', () => {
-  const p1 = adhan.CalculationMethod.MuslimWorldLeague();
+  const p1 = CalculationMethod.MuslimWorldLeague();
   expect(p1.fajrAngle).toBe(18);
   expect(p1.ishaAngle).toBe(17);
   expect(p1.ishaInterval).toBe(0);
   expect(p1.method).toBe('MuslimWorldLeague');
 
-  const p2 = adhan.CalculationMethod.Egyptian();
+  const p2 = CalculationMethod.Egyptian();
   expect(p2.fajrAngle).toBe(19.5);
   expect(p2.ishaAngle).toBe(17.5);
   expect(p2.ishaInterval).toBe(0);
   expect(p2.method).toBe('Egyptian');
 
-  const p3 = adhan.CalculationMethod.Karachi();
+  const p3 = CalculationMethod.Karachi();
   expect(p3.fajrAngle).toBe(18);
   expect(p3.ishaAngle).toBe(18);
   expect(p3.ishaInterval).toBe(0);
   expect(p3.method).toBe('Karachi');
 
-  const p4 = adhan.CalculationMethod.UmmAlQura();
+  const p4 = CalculationMethod.UmmAlQura();
   expect(p4.fajrAngle).toBe(18.5);
   expect(p4.ishaAngle).toBe(0);
   expect(p4.ishaInterval).toBe(90);
   expect(p4.method).toBe('UmmAlQura');
 
-  const p5 = adhan.CalculationMethod.Dubai();
+  const p5 = CalculationMethod.Dubai();
   expect(p5.fajrAngle).toBe(18.2);
   expect(p5.ishaAngle).toBe(18.2);
   expect(p5.ishaInterval).toBe(0);
   expect(p5.method).toBe('Dubai');
 
-  const p6 = adhan.CalculationMethod.MoonsightingCommittee();
+  const p6 = CalculationMethod.MoonsightingCommittee();
   expect(p6.fajrAngle).toBe(18);
   expect(p6.ishaAngle).toBe(18);
   expect(p6.ishaInterval).toBe(0);
   expect(p6.method).toBe('MoonsightingCommittee');
 
-  const p7 = adhan.CalculationMethod.NorthAmerica();
+  const p7 = CalculationMethod.NorthAmerica();
   expect(p7.fajrAngle).toBe(15);
   expect(p7.ishaAngle).toBe(15);
   expect(p7.ishaInterval).toBe(0);
   expect(p7.method).toBe('NorthAmerica');
 
-  const p8 = adhan.CalculationMethod.Other();
+  const p8 = CalculationMethod.Other();
   expect(p8.fajrAngle).toBe(0);
   expect(p8.ishaAngle).toBe(0);
   expect(p8.ishaInterval).toBe(0);
   expect(p8.method).toBe('Other');
 
-  const p9 = adhan.CalculationMethod.Kuwait();
+  const p9 = CalculationMethod.Kuwait();
   expect(p9.fajrAngle).toBe(18);
   expect(p9.ishaAngle).toBe(17.5);
   expect(p9.ishaInterval).toBe(0);
   expect(p9.method).toBe('Kuwait');
 
-  const p10 = adhan.CalculationMethod.Qatar();
+  const p10 = CalculationMethod.Qatar();
   expect(p10.fajrAngle).toBe(18);
   expect(p10.ishaAngle).toBe(0);
   expect(p10.ishaInterval).toBe(90);
   expect(p10.method).toBe('Qatar');
 
-  const p11 = adhan.CalculationMethod.Singapore();
+  const p11 = CalculationMethod.Singapore();
   expect(p11.fajrAngle).toBe(20);
   expect(p11.ishaAngle).toBe(18);
   expect(p11.ishaInterval).toBe(0);
   expect(p11.method).toBe('Singapore');
 
-  const p12 = adhan.CalculationMethod.Tehran();
+  const p12 = CalculationMethod.Tehran();
   expect(p12.fajrAngle).toBe(17.7);
   expect(p12.ishaAngle).toBe(14);
   expect(p12.ishaInterval).toBe(0);
   expect(p12.method).toBe('Tehran');
 
-  const p13 = adhan.CalculationMethod.Turkey();
+  const p13 = CalculationMethod.Turkey();
   expect(p13.fajrAngle).toBe(18);
   expect(p13.ishaAngle).toBe(17);
   expect(p13.ishaInterval).toBe(0);
   expect(p13.method).toBe('Turkey');
 
-  const p14 = new adhan.CalculationParameters(null, 18, 17);
+  const p14 = new CalculationParameters(null, 18, 17);
   expect(p14.fajrAngle).toBe(18);
   expect(p14.ishaAngle).toBe(17);
   expect(p14.ishaInterval).toBe(0);
@@ -126,13 +130,9 @@ test('Verifying the angles defined by the calculation method', () => {
 
 test('calculating prayer times', () => {
   const date = new Date(2015, 6, 12);
-  const params = adhan.CalculationMethod.NorthAmerica();
-  params.madhab = adhan.Madhab.Hanafi;
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(35.775, -78.6336),
-    date,
-    params,
-  );
+  const params = CalculationMethod.NorthAmerica();
+  params.madhab = Madhab.Hanafi;
+  const p = new PrayerTimes(new Coordinates(35.775, -78.6336), date, params);
 
   expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
     '4:42 AM',
@@ -155,13 +155,9 @@ test('calculating prayer times', () => {
 
 test('using offsets to manually adjust prayer times', () => {
   const date = new Date(2015, 11, 1);
-  const params = adhan.CalculationMethod.MuslimWorldLeague();
-  params.madhab = adhan.Madhab.Shafi;
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(35.775, -78.6336),
-    date,
-    params,
-  );
+  const params = CalculationMethod.MuslimWorldLeague();
+  params.madhab = Madhab.Shafi;
+  const p = new PrayerTimes(new Coordinates(35.775, -78.6336), date, params);
   expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
     '5:35 AM',
   );
@@ -186,11 +182,7 @@ test('using offsets to manually adjust prayer times', () => {
   params.adjustments.maghrib = 10;
   params.adjustments.isha = 10;
 
-  const p2 = new adhan.PrayerTimes(
-    new adhan.Coordinates(35.775, -78.6336),
-    date,
-    params,
-  );
+  const p2 = new PrayerTimes(new Coordinates(35.775, -78.6336), date, params);
   expect(moment(p2.fajr).tz('America/New_York').format('h:mm A')).toBe(
     '5:45 AM',
   );
@@ -214,10 +206,10 @@ test('using offsets to manually adjust prayer times', () => {
 test('calculating prayer times using the Moonsighting Committee calculation method', () => {
   // Values from http://www.moonsighting.com/pray.php
   const date = new Date(2016, 0, 31);
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(35.775, -78.6336),
+  const p = new PrayerTimes(
+    new Coordinates(35.775, -78.6336),
     date,
-    adhan.CalculationMethod.MoonsightingCommittee(),
+    CalculationMethod.MoonsightingCommittee(),
   );
   expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
     '5:48 AM',
@@ -240,13 +232,9 @@ test('calculating prayer times using the Moonsighting Committee calculation meth
 test('calculating Moonsighting Committee prayer times at a high latitude location', () => {
   // Values from http://www.moonsighting.com/pray.php
   const date = new Date(2016, 0, 1);
-  const params = adhan.CalculationMethod.MoonsightingCommittee();
-  params.madhab = adhan.Madhab.Hanafi;
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(59.9094, 10.7349),
-    date,
-    params,
-  );
+  const params = CalculationMethod.MoonsightingCommittee();
+  params.madhab = Madhab.Hanafi;
+  const p = new PrayerTimes(new Coordinates(59.9094, 10.7349), date, params);
   expect(moment(p.fajr).tz('Europe/Oslo').format('h:mm A')).toBe('7:34 AM');
   expect(moment(p.sunrise).tz('Europe/Oslo').format('h:mm A')).toBe('9:19 AM');
   expect(moment(p.dhuhr).tz('Europe/Oslo').format('h:mm A')).toBe('12:25 PM');
@@ -258,12 +246,8 @@ test('calculating Moonsighting Committee prayer times at a high latitude locatio
 test('calculating times for turkey method', () => {
   // values from https://namazvakitleri.diyanet.gov.tr/en-US/9541/prayer-time-for-istanbul
   const date = new Date(2020, 3, 16);
-  const params = adhan.CalculationMethod.Turkey();
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(41.005616, 28.97638),
-    date,
-    params,
-  );
+  const params = CalculationMethod.Turkey();
+  const p = new PrayerTimes(new Coordinates(41.005616, 28.97638), date, params);
   expect(moment(p.fajr).tz('Europe/Istanbul').format('h:mm A')).toBe('4:44 AM');
   expect(moment(p.sunrise).tz('Europe/Istanbul').format('h:mm A')).toBe(
     '6:16 AM',
@@ -280,9 +264,9 @@ test('calculating times for turkey method', () => {
 
 test('calculating times for the egyptian method', () => {
   const date = new Date(2020, 0, 1);
-  const params = adhan.CalculationMethod.Egyptian();
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(30.028703, 31.249528),
+  const params = CalculationMethod.Egyptian();
+  const p = new PrayerTimes(
+    new Coordinates(30.028703, 31.249528),
     date,
     params,
   );
@@ -296,9 +280,9 @@ test('calculating times for the egyptian method', () => {
 
 test('calculating times for the singapore method', () => {
   const date = new Date(2021, 5, 14);
-  const params = adhan.CalculationMethod.Singapore();
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(3.7333333333, 101.3833333333),
+  const params = CalculationMethod.Singapore();
+  const p = new PrayerTimes(
+    new Coordinates(3.7333333333, 101.3833333333),
     date,
     params,
   );
@@ -324,73 +308,53 @@ test('calculating times for the singapore method', () => {
 
 test('getting the time for a given prayer', () => {
   const date = new Date(2016, 6, 1);
-  const params = adhan.CalculationMethod.MuslimWorldLeague();
-  params.madhab = adhan.Madhab.Hanafi;
-  params.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle;
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(59.9094, 10.7349),
-    date,
-    params,
-  );
-  expect(p.timeForPrayer(adhan.Prayer.Fajr)).toBe(p.fajr);
-  expect(p.timeForPrayer(adhan.Prayer.Sunrise)).toBe(p.sunrise);
-  expect(p.timeForPrayer(adhan.Prayer.Dhuhr)).toBe(p.dhuhr);
-  expect(p.timeForPrayer(adhan.Prayer.Asr)).toBe(p.asr);
-  expect(p.timeForPrayer(adhan.Prayer.Maghrib)).toBe(p.maghrib);
-  expect(p.timeForPrayer(adhan.Prayer.Isha)).toBe(p.isha);
-  expect(p.timeForPrayer(adhan.Prayer.None)).toBeNull();
+  const params = CalculationMethod.MuslimWorldLeague();
+  params.madhab = Madhab.Hanafi;
+  params.highLatitudeRule = HighLatitudeRule.TwilightAngle;
+  const p = new PrayerTimes(new Coordinates(59.9094, 10.7349), date, params);
+  expect(p.timeForPrayer(Prayer.Fajr)).toBe(p.fajr);
+  expect(p.timeForPrayer(Prayer.Sunrise)).toBe(p.sunrise);
+  expect(p.timeForPrayer(Prayer.Dhuhr)).toBe(p.dhuhr);
+  expect(p.timeForPrayer(Prayer.Asr)).toBe(p.asr);
+  expect(p.timeForPrayer(Prayer.Maghrib)).toBe(p.maghrib);
+  expect(p.timeForPrayer(Prayer.Isha)).toBe(p.isha);
+  expect(p.timeForPrayer(Prayer.None)).toBeNull();
 });
 
 test('getting the current prayer', () => {
   const date = new Date(2015, 8, 1);
-  const params = adhan.CalculationMethod.Karachi();
-  params.madhab = adhan.Madhab.Hanafi;
-  params.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle;
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(33.720817, 73.090032),
+  const params = CalculationMethod.Karachi();
+  params.madhab = Madhab.Hanafi;
+  params.highLatitudeRule = HighLatitudeRule.TwilightAngle;
+  const p = new PrayerTimes(
+    new Coordinates(33.720817, 73.090032),
     date,
     params,
   );
-  expect(p.currentPrayer(dateByAddingSeconds(p.fajr, -1))).toBe(
-    adhan.Prayer.None,
-  );
-  expect(p.currentPrayer(p.fajr)).toBe(adhan.Prayer.Fajr);
-  expect(p.currentPrayer(dateByAddingSeconds(p.fajr, 1))).toBe(
-    adhan.Prayer.Fajr,
-  );
+  expect(p.currentPrayer(dateByAddingSeconds(p.fajr, -1))).toBe(Prayer.None);
+  expect(p.currentPrayer(p.fajr)).toBe(Prayer.Fajr);
+  expect(p.currentPrayer(dateByAddingSeconds(p.fajr, 1))).toBe(Prayer.Fajr);
   expect(p.currentPrayer(dateByAddingSeconds(p.sunrise, 1))).toBe(
-    adhan.Prayer.Sunrise,
+    Prayer.Sunrise,
   );
-  expect(p.currentPrayer(dateByAddingSeconds(p.dhuhr, 1))).toBe(
-    adhan.Prayer.Dhuhr,
-  );
-  expect(p.currentPrayer(dateByAddingSeconds(p.asr, 1))).toBe(adhan.Prayer.Asr);
+  expect(p.currentPrayer(dateByAddingSeconds(p.dhuhr, 1))).toBe(Prayer.Dhuhr);
+  expect(p.currentPrayer(dateByAddingSeconds(p.asr, 1))).toBe(Prayer.Asr);
   expect(p.currentPrayer(dateByAddingSeconds(p.maghrib, 1))).toBe(
-    adhan.Prayer.Maghrib,
+    Prayer.Maghrib,
   );
-  expect(p.currentPrayer(dateByAddingSeconds(p.isha, 1))).toBe(
-    adhan.Prayer.Isha,
-  );
+  expect(p.currentPrayer(dateByAddingSeconds(p.isha, 1))).toBe(Prayer.Isha);
 });
 
 test('changing the time for asr with different madhabs', () => {
   const date = new Date(2015, 11, 1);
-  const params = adhan.CalculationMethod.MuslimWorldLeague();
-  params.madhab = adhan.Madhab.Shafi;
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(35.775, -78.6336),
-    date,
-    params,
-  );
+  const params = CalculationMethod.MuslimWorldLeague();
+  params.madhab = Madhab.Shafi;
+  const p = new PrayerTimes(new Coordinates(35.775, -78.6336), date, params);
   expect(moment(p.asr).tz('America/New_York').format('h:mm A')).toBe('2:42 PM');
 
-  params.madhab = adhan.Madhab.Hanafi;
+  params.madhab = Madhab.Hanafi;
 
-  const p2 = new adhan.PrayerTimes(
-    new adhan.Coordinates(35.775, -78.6336),
-    date,
-    params,
-  );
+  const p2 = new PrayerTimes(new Coordinates(35.775, -78.6336), date, params);
   expect(moment(p2.asr).tz('America/New_York').format('h:mm A')).toBe(
     '3:22 PM',
   );
@@ -398,39 +362,31 @@ test('changing the time for asr with different madhabs', () => {
 
 test('getting the next prayer', () => {
   const date = new Date(2015, 8, 1);
-  const params = adhan.CalculationMethod.Karachi();
-  params.madhab = adhan.Madhab.Hanafi;
-  params.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle;
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(33.720817, 73.090032),
+  const params = CalculationMethod.Karachi();
+  params.madhab = Madhab.Hanafi;
+  params.highLatitudeRule = HighLatitudeRule.TwilightAngle;
+  const p = new PrayerTimes(
+    new Coordinates(33.720817, 73.090032),
     date,
     params,
   );
-  expect(p.nextPrayer(dateByAddingSeconds(p.fajr, -1))).toBe(adhan.Prayer.Fajr);
-  expect(p.nextPrayer(p.fajr)).toBe(adhan.Prayer.Sunrise);
-  expect(p.nextPrayer(dateByAddingSeconds(p.fajr, 1))).toBe(
-    adhan.Prayer.Sunrise,
-  );
-  expect(p.nextPrayer(dateByAddingSeconds(p.sunrise, 1))).toBe(
-    adhan.Prayer.Dhuhr,
-  );
-  expect(p.nextPrayer(dateByAddingSeconds(p.dhuhr, 1))).toBe(adhan.Prayer.Asr);
-  expect(p.nextPrayer(dateByAddingSeconds(p.asr, 1))).toBe(
-    adhan.Prayer.Maghrib,
-  );
-  expect(p.nextPrayer(dateByAddingSeconds(p.maghrib, 1))).toBe(
-    adhan.Prayer.Isha,
-  );
-  expect(p.nextPrayer(dateByAddingSeconds(p.isha, 1))).toBe(adhan.Prayer.None);
+  expect(p.nextPrayer(dateByAddingSeconds(p.fajr, -1))).toBe(Prayer.Fajr);
+  expect(p.nextPrayer(p.fajr)).toBe(Prayer.Sunrise);
+  expect(p.nextPrayer(dateByAddingSeconds(p.fajr, 1))).toBe(Prayer.Sunrise);
+  expect(p.nextPrayer(dateByAddingSeconds(p.sunrise, 1))).toBe(Prayer.Dhuhr);
+  expect(p.nextPrayer(dateByAddingSeconds(p.dhuhr, 1))).toBe(Prayer.Asr);
+  expect(p.nextPrayer(dateByAddingSeconds(p.asr, 1))).toBe(Prayer.Maghrib);
+  expect(p.nextPrayer(dateByAddingSeconds(p.maghrib, 1))).toBe(Prayer.Isha);
+  expect(p.nextPrayer(dateByAddingSeconds(p.isha, 1))).toBe(Prayer.None);
 });
 
 test('getting the current next prayer', () => {
   const date = new Date();
-  const params = adhan.CalculationMethod.Karachi();
-  params.madhab = adhan.Madhab.Hanafi;
-  params.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle;
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(33.720817, 73.090032),
+  const params = CalculationMethod.Karachi();
+  params.madhab = Madhab.Hanafi;
+  params.highLatitudeRule = HighLatitudeRule.TwilightAngle;
+  const p = new PrayerTimes(
+    new Coordinates(33.720817, 73.090032),
     date,
     params,
   );
@@ -440,22 +396,20 @@ test('getting the current next prayer', () => {
 });
 
 test('getting the madhab shadow length', () => {
-  expect(shadowLength(adhan.Madhab.Shafi)).toBe(1);
-  expect(shadowLength(adhan.Madhab.Hanafi)).toBe(2);
+  expect(shadowLength(Madhab.Shafi)).toBe(1);
+  expect(shadowLength(Madhab.Hanafi)).toBe(2);
   expect(() => {
-    shadowLength(
-      (adhan.Madhab as unknown as { Foo: ValueOf<typeof adhan.Madhab> }).Foo,
-    );
+    shadowLength((Madhab as unknown as { Foo: ValueOf<typeof Madhab> }).Foo);
   }).toThrow();
 });
 
 test('adjusting prayer time with high latitude rule', () => {
   const date = new Date(2020, 5, 15);
-  const params = adhan.CalculationMethod.MuslimWorldLeague();
+  const params = CalculationMethod.MuslimWorldLeague();
   const tzid = 'Europe/London';
-  const coords = new adhan.Coordinates(55.983226, -3.216649);
+  const coords = new Coordinates(55.983226, -3.216649);
 
-  const p1 = new adhan.PrayerTimes(coords, date, params);
+  const p1 = new PrayerTimes(coords, date, params);
   expect(moment(p1.fajr).tz(tzid).format('h:mm A')).toBe('1:14 AM');
   expect(moment(p1.sunrise).tz(tzid).format('h:mm A')).toBe('4:26 AM');
   expect(moment(p1.dhuhr).tz(tzid).format('h:mm A')).toBe('1:14 PM');
@@ -463,8 +417,8 @@ test('adjusting prayer time with high latitude rule', () => {
   expect(moment(p1.maghrib).tz(tzid).format('h:mm A')).toBe('10:01 PM');
   expect(moment(p1.isha).tz(tzid).format('h:mm A')).toBe('1:14 AM');
 
-  params.highLatitudeRule = adhan.HighLatitudeRule.SeventhOfTheNight;
-  const p2 = new adhan.PrayerTimes(coords, date, params);
+  params.highLatitudeRule = HighLatitudeRule.SeventhOfTheNight;
+  const p2 = new PrayerTimes(coords, date, params);
   expect(moment(p2.fajr).tz(tzid).format('h:mm A')).toBe('3:31 AM');
   expect(moment(p2.sunrise).tz(tzid).format('h:mm A')).toBe('4:26 AM');
   expect(moment(p2.dhuhr).tz(tzid).format('h:mm A')).toBe('1:14 PM');
@@ -472,8 +426,8 @@ test('adjusting prayer time with high latitude rule', () => {
   expect(moment(p2.maghrib).tz(tzid).format('h:mm A')).toBe('10:01 PM');
   expect(moment(p2.isha).tz(tzid).format('h:mm A')).toBe('10:56 PM');
 
-  params.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle;
-  const p3 = new adhan.PrayerTimes(coords, date, params);
+  params.highLatitudeRule = HighLatitudeRule.TwilightAngle;
+  const p3 = new PrayerTimes(coords, date, params);
   expect(moment(p3.fajr).tz(tzid).format('h:mm A')).toBe('2:31 AM');
   expect(moment(p3.sunrise).tz(tzid).format('h:mm A')).toBe('4:26 AM');
   expect(moment(p3.dhuhr).tz(tzid).format('h:mm A')).toBe('1:14 PM');
@@ -483,14 +437,14 @@ test('adjusting prayer time with high latitude rule', () => {
 });
 
 test('getting recommended high latitude rule', () => {
-  const coords1 = new adhan.Coordinates(45.983226, -3.216649);
-  expect(adhan.HighLatitudeRule.recommended(coords1)).toBe(
-    adhan.HighLatitudeRule.MiddleOfTheNight,
+  const coords1 = new Coordinates(45.983226, -3.216649);
+  expect(HighLatitudeRule.recommended(coords1)).toBe(
+    HighLatitudeRule.MiddleOfTheNight,
   );
 
-  const coords2 = new adhan.Coordinates(48.983226, -3.216649);
-  expect(adhan.HighLatitudeRule.recommended(coords2)).toBe(
-    adhan.HighLatitudeRule.SeventhOfTheNight,
+  const coords2 = new Coordinates(48.983226, -3.216649);
+  expect(HighLatitudeRule.recommended(coords2)).toBe(
+    HighLatitudeRule.SeventhOfTheNight,
   );
 });
 
@@ -498,14 +452,10 @@ describe('Moonsighting Committee method with shafaq general', () => {
   // Values from http://www.moonsighting.com/pray.php
   test('Shafaq general in winter', () => {
     const date = new Date(2021, 0, 1);
-    const params = adhan.CalculationMethod.MoonsightingCommittee();
+    const params = CalculationMethod.MoonsightingCommittee();
     params.shafaq = Shafaq.General;
-    params.madhab = adhan.Madhab.Hanafi;
-    const p = new adhan.PrayerTimes(
-      new adhan.Coordinates(43.494, -79.844),
-      date,
-      params,
-    );
+    params.madhab = Madhab.Hanafi;
+    const p = new PrayerTimes(new Coordinates(43.494, -79.844), date, params);
     expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
       '6:16 AM',
     );
@@ -528,14 +478,10 @@ describe('Moonsighting Committee method with shafaq general', () => {
 
   test('Shafaq general in Spring', () => {
     const date = new Date(2021, 3, 1);
-    const params = adhan.CalculationMethod.MoonsightingCommittee();
+    const params = CalculationMethod.MoonsightingCommittee();
     params.shafaq = Shafaq.General;
-    params.madhab = adhan.Madhab.Hanafi;
-    const p = new adhan.PrayerTimes(
-      new adhan.Coordinates(43.494, -79.844),
-      date,
-      params,
-    );
+    params.madhab = Madhab.Hanafi;
+    const p = new PrayerTimes(new Coordinates(43.494, -79.844), date, params);
     expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
       '5:28 AM',
     );
@@ -558,14 +504,10 @@ describe('Moonsighting Committee method with shafaq general', () => {
 
   test('Shafaq general in Summer', () => {
     const date = new Date(2021, 6, 1);
-    const params = adhan.CalculationMethod.MoonsightingCommittee();
+    const params = CalculationMethod.MoonsightingCommittee();
     params.shafaq = Shafaq.General;
-    params.madhab = adhan.Madhab.Hanafi;
-    const p = new adhan.PrayerTimes(
-      new adhan.Coordinates(43.494, -79.844),
-      date,
-      params,
-    );
+    params.madhab = Madhab.Hanafi;
+    const p = new PrayerTimes(new Coordinates(43.494, -79.844), date, params);
     expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
       '3:52 AM',
     );
@@ -588,14 +530,10 @@ describe('Moonsighting Committee method with shafaq general', () => {
 
   test('Shafaq general in Fall', () => {
     const date = new Date(2021, 10, 1);
-    const params = adhan.CalculationMethod.MoonsightingCommittee();
+    const params = CalculationMethod.MoonsightingCommittee();
     params.shafaq = Shafaq.General;
-    params.madhab = adhan.Madhab.Hanafi;
-    const p = new adhan.PrayerTimes(
-      new adhan.Coordinates(43.494, -79.844),
-      date,
-      params,
-    );
+    params.madhab = Madhab.Hanafi;
+    const p = new PrayerTimes(new Coordinates(43.494, -79.844), date, params);
     expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
       '6:22 AM',
     );
@@ -621,13 +559,9 @@ describe('Moonsighting Committee method with shafaq ahmer', () => {
   // Values from http://www.moonsighting.com/pray.php
   test('Shafaq ahmer in winter', () => {
     const date = new Date(2021, 0, 1);
-    const params = adhan.CalculationMethod.MoonsightingCommittee();
+    const params = CalculationMethod.MoonsightingCommittee();
     params.shafaq = Shafaq.Ahmer;
-    const p = new adhan.PrayerTimes(
-      new adhan.Coordinates(43.494, -79.844),
-      date,
-      params,
-    );
+    const p = new PrayerTimes(new Coordinates(43.494, -79.844), date, params);
     expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
       '6:16 AM',
     );
@@ -650,13 +584,9 @@ describe('Moonsighting Committee method with shafaq ahmer', () => {
 
   test('Shafaq ahmer in Spring', () => {
     const date = new Date(2021, 3, 1);
-    const params = adhan.CalculationMethod.MoonsightingCommittee();
+    const params = CalculationMethod.MoonsightingCommittee();
     params.shafaq = Shafaq.Ahmer;
-    const p = new adhan.PrayerTimes(
-      new adhan.Coordinates(43.494, -79.844),
-      date,
-      params,
-    );
+    const p = new PrayerTimes(new Coordinates(43.494, -79.844), date, params);
     expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
       '5:28 AM',
     );
@@ -679,13 +609,9 @@ describe('Moonsighting Committee method with shafaq ahmer', () => {
 
   test('Shafaq ahmer in Summer', () => {
     const date = new Date(2021, 6, 1);
-    const params = adhan.CalculationMethod.MoonsightingCommittee();
+    const params = CalculationMethod.MoonsightingCommittee();
     params.shafaq = Shafaq.Ahmer;
-    const p = new adhan.PrayerTimes(
-      new adhan.Coordinates(43.494, -79.844),
-      date,
-      params,
-    );
+    const p = new PrayerTimes(new Coordinates(43.494, -79.844), date, params);
     expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
       '3:52 AM',
     );
@@ -708,13 +634,9 @@ describe('Moonsighting Committee method with shafaq ahmer', () => {
 
   test('Shafaq ahmer in Fall', () => {
     const date = new Date(2021, 10, 1);
-    const params = adhan.CalculationMethod.MoonsightingCommittee();
+    const params = CalculationMethod.MoonsightingCommittee();
     params.shafaq = Shafaq.Ahmer;
-    const p = new adhan.PrayerTimes(
-      new adhan.Coordinates(43.494, -79.844),
-      date,
-      params,
-    );
+    const p = new PrayerTimes(new Coordinates(43.494, -79.844), date, params);
     expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
       '6:22 AM',
     );
@@ -740,14 +662,10 @@ describe('Moonsighting Committee method with shafaq abyad', () => {
   // Values from http://www.moonsighting.com/pray.php
   test('Shafaq abyad in winter', () => {
     const date = new Date(2021, 0, 1);
-    const params = adhan.CalculationMethod.MoonsightingCommittee();
+    const params = CalculationMethod.MoonsightingCommittee();
     params.shafaq = Shafaq.Abyad;
-    params.madhab = adhan.Madhab.Hanafi;
-    const p = new adhan.PrayerTimes(
-      new adhan.Coordinates(43.494, -79.844),
-      date,
-      params,
-    );
+    params.madhab = Madhab.Hanafi;
+    const p = new PrayerTimes(new Coordinates(43.494, -79.844), date, params);
     expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
       '6:16 AM',
     );
@@ -770,14 +688,10 @@ describe('Moonsighting Committee method with shafaq abyad', () => {
 
   test('Shafaq abyad in Spring', () => {
     const date = new Date(2021, 3, 1);
-    const params = adhan.CalculationMethod.MoonsightingCommittee();
+    const params = CalculationMethod.MoonsightingCommittee();
     params.shafaq = Shafaq.Abyad;
-    params.madhab = adhan.Madhab.Hanafi;
-    const p = new adhan.PrayerTimes(
-      new adhan.Coordinates(43.494, -79.844),
-      date,
-      params,
-    );
+    params.madhab = Madhab.Hanafi;
+    const p = new PrayerTimes(new Coordinates(43.494, -79.844), date, params);
     expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
       '5:28 AM',
     );
@@ -800,14 +714,10 @@ describe('Moonsighting Committee method with shafaq abyad', () => {
 
   test('Shafaq abyad in Summer', () => {
     const date = new Date(2021, 6, 1);
-    const params = adhan.CalculationMethod.MoonsightingCommittee();
+    const params = CalculationMethod.MoonsightingCommittee();
     params.shafaq = Shafaq.Abyad;
-    params.madhab = adhan.Madhab.Hanafi;
-    const p = new adhan.PrayerTimes(
-      new adhan.Coordinates(43.494, -79.844),
-      date,
-      params,
-    );
+    params.madhab = Madhab.Hanafi;
+    const p = new PrayerTimes(new Coordinates(43.494, -79.844), date, params);
     expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
       '3:52 AM',
     );
@@ -830,14 +740,10 @@ describe('Moonsighting Committee method with shafaq abyad', () => {
 
   test('Shafaq abyad in Fall', () => {
     const date = new Date(2021, 10, 1);
-    const params = adhan.CalculationMethod.MoonsightingCommittee();
+    const params = CalculationMethod.MoonsightingCommittee();
     params.shafaq = Shafaq.Abyad;
-    params.madhab = adhan.Madhab.Hanafi;
-    const p = new adhan.PrayerTimes(
-      new adhan.Coordinates(43.494, -79.844),
-      date,
-      params,
-    );
+    params.madhab = Madhab.Hanafi;
+    const p = new PrayerTimes(new Coordinates(43.494, -79.844), date, params);
     expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
       '6:22 AM',
     );
@@ -864,27 +770,28 @@ describe('Polar circle resolution cases', () => {
   const regularDate = new Date(2020, 4, 15, 20, 0, 0, 0);
   const dateAffectedByPolarNight = new Date(2020, 11, 21, 20, 0, 0, 0);
   const dateAffectedByMidnightSun = new Date(2020, 5, 21, 20, 0, 0, 0);
-  const regularCoordinates = new adhan.Coordinates(31.947351, 35.227163);
-  const ArjeplogSweden = new adhan.Coordinates(66.7222444, 17.7189);
-  const AmundsenScottAntarctic = new adhan.Coordinates(-84.996, 0.01013);
-  const unresolvedParams = adhan.CalculationMethod.MuslimWorldLeague();
-  const aqrabBaladParams = adhan.CalculationMethod.MuslimWorldLeague();
+  const regularCoordinates = new Coordinates(31.947351, 35.227163);
+  const ArjeplogSweden = new Coordinates(66.7222444, 17.7189);
+  const AmundsenScottAntarctic = new Coordinates(-84.996, 0.01013);
+  const unresolvedParams = CalculationMethod.MuslimWorldLeague();
+  const aqrabBaladParams = CalculationMethod.MuslimWorldLeague();
   aqrabBaladParams.polarCircleResolution =
-    adhan.PolarCircleResolution.AqrabBalad;
-  const aqrabYaumParams = adhan.CalculationMethod.MuslimWorldLeague();
-  aqrabYaumParams.polarCircleResolution = adhan.PolarCircleResolution.AqrabYaum;
+    polarCircleResolver.PolarCircleResolution.AqrabBalad;
+  const aqrabYaumParams = CalculationMethod.MuslimWorldLeague();
+  aqrabYaumParams.polarCircleResolution =
+    polarCircleResolver.PolarCircleResolution.AqrabYaum;
 
   describe('Regular computation', () => {
     it('should not attempt to do any resolution if the resolver is set to unresolved', () => {
       const spy = jest.spyOn(polarCircleResolver, 'polarCircleResolvedValues');
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const prayersTimes1 = new adhan.PrayerTimes(
+      const prayersTimes1 = new PrayerTimes(
         ArjeplogSweden,
         dateAffectedByMidnightSun,
         unresolvedParams,
       );
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const prayersTimes2 = new adhan.PrayerTimes(
+      const prayersTimes2 = new PrayerTimes(
         ArjeplogSweden,
         dateAffectedByMidnightSun,
         unresolvedParams,
@@ -896,13 +803,13 @@ describe('Polar circle resolution cases', () => {
     it('should not attempt to do any resolution if the date is affected neither by the polar night nor by the midnight sun', () => {
       const spy = jest.spyOn(polarCircleResolver, 'polarCircleResolvedValues');
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const prayersTimes1 = new adhan.PrayerTimes(
+      const prayersTimes1 = new PrayerTimes(
         ArjeplogSweden,
         regularDate,
         aqrabBaladParams,
       );
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const prayersTimes2 = new adhan.PrayerTimes(
+      const prayersTimes2 = new PrayerTimes(
         ArjeplogSweden,
         regularDate,
         aqrabYaumParams,
@@ -914,13 +821,13 @@ describe('Polar circle resolution cases', () => {
     it('should not make any search if the location is outside the polar circles', () => {
       const spy = jest.spyOn(polarCircleResolver, 'polarCircleResolvedValues');
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const prayersTimes1 = new adhan.PrayerTimes(
+      const prayersTimes1 = new PrayerTimes(
         regularCoordinates,
         dateAffectedByPolarNight,
         aqrabBaladParams,
       );
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const prayersTimes2 = new adhan.PrayerTimes(
+      const prayersTimes2 = new PrayerTimes(
         regularCoordinates,
         dateAffectedByPolarNight,
         aqrabYaumParams,
@@ -932,7 +839,7 @@ describe('Polar circle resolution cases', () => {
 
   describe('Midnight Sun case', () => {
     it('should fail to compute targeted prayer times with the "unresolved" resolver', () => {
-      const prayersTimes = new adhan.PrayerTimes(
+      const prayersTimes = new PrayerTimes(
         ArjeplogSweden,
         dateAffectedByMidnightSun,
         unresolvedParams,
@@ -944,7 +851,7 @@ describe('Polar circle resolution cases', () => {
     });
 
     it('should succeed in computing all prayers times with the "aqrabBalad" resolver', () => {
-      const prayersTimes = new adhan.PrayerTimes(
+      const prayersTimes = new PrayerTimes(
         ArjeplogSweden,
         dateAffectedByMidnightSun,
         aqrabBaladParams,
@@ -956,7 +863,7 @@ describe('Polar circle resolution cases', () => {
     });
 
     it('should succeed in computing all prayers times with the "aqrabYaum" resolver', () => {
-      const prayersTimes = new adhan.PrayerTimes(
+      const prayersTimes = new PrayerTimes(
         ArjeplogSweden,
         dateAffectedByMidnightSun,
         aqrabYaumParams,
@@ -970,7 +877,7 @@ describe('Polar circle resolution cases', () => {
 
   describe('Polar Night case', () => {
     it('should fail to compute targeted prayer times with the "unresolved" resolver', () => {
-      const prayersTimes = new adhan.PrayerTimes(
+      const prayersTimes = new PrayerTimes(
         AmundsenScottAntarctic,
         dateAffectedByPolarNight,
         unresolvedParams,
@@ -982,7 +889,7 @@ describe('Polar circle resolution cases', () => {
     });
 
     it('should succeed in computing all prayers times with the "aqrabBalad" resolver', () => {
-      const prayersTimes = new adhan.PrayerTimes(
+      const prayersTimes = new PrayerTimes(
         AmundsenScottAntarctic,
         dateAffectedByPolarNight,
         aqrabBaladParams,
@@ -994,7 +901,7 @@ describe('Polar circle resolution cases', () => {
     });
 
     it('should succeed in computing all prayers times with the "aqrabYaum" resolver', () => {
-      const prayersTimes = new adhan.PrayerTimes(
+      const prayersTimes = new PrayerTimes(
         AmundsenScottAntarctic,
         dateAffectedByPolarNight,
         aqrabYaumParams,
@@ -1006,13 +913,14 @@ describe('Polar circle resolution cases', () => {
     });
 
     test('calculating times for the polar circle', () => {
-      const coordinates = new adhan.Coordinates(66.7222444, 17.7189);
-      const params = adhan.CalculationMethod.MuslimWorldLeague();
-      params.polarCircleResolution = adhan.PolarCircleResolution.AqrabYaum;
-      params.highLatitudeRule = adhan.HighLatitudeRule.SeventhOfTheNight;
+      const coordinates = new Coordinates(66.7222444, 17.7189);
+      const params = CalculationMethod.MuslimWorldLeague();
+      params.polarCircleResolution =
+        polarCircleResolver.PolarCircleResolution.AqrabYaum;
+      params.highLatitudeRule = HighLatitudeRule.SeventhOfTheNight;
       const date = new Date(2020, 5, 21);
 
-      const p = new adhan.PrayerTimes(coordinates, date, params);
+      const p = new PrayerTimes(coordinates, date, params);
       expect(
         moment(p.fajr).tz('Europe/Stockholm').format('MMMM DD, YYYY h:mm A'),
       ).toBe('June 21, 2020 12:40 AM');

--- a/test/dist.test.ts
+++ b/test/dist.test.ts
@@ -1,5 +1,10 @@
-import adhan from '../src/Adhan';
 import moment from 'moment-timezone';
+import CalculationMethod from '../src/CalculationMethod';
+import Coordinates from '../src/Coordinates';
+import HighLatitudeRule from '../src/HighLatitudeRule';
+import { Madhab } from '../src/Madhab';
+import Prayer from '../src/Prayer';
+import PrayerTimes from '../src/PrayerTimes';
 
 function dateByAddingSeconds(date: Date, seconds: number) {
   return new Date(date.getTime() + seconds * 1000);
@@ -7,13 +12,9 @@ function dateByAddingSeconds(date: Date, seconds: number) {
 
 test('calculating prayer times', () => {
   const date = new Date(2015, 6, 12);
-  const params = adhan.CalculationMethod.NorthAmerica();
-  params.madhab = adhan.Madhab.Hanafi;
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(35.775, -78.6336),
-    date,
-    params,
-  );
+  const params = CalculationMethod.NorthAmerica();
+  params.madhab = Madhab.Hanafi;
+  const p = new PrayerTimes(new Coordinates(35.775, -78.6336), date, params);
 
   expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
     '4:42 AM',
@@ -36,13 +37,9 @@ test('calculating prayer times', () => {
 
 test('useing offsets to manually adjust prayer times', () => {
   const date = new Date(2015, 11, 1);
-  const params = adhan.CalculationMethod.MuslimWorldLeague();
-  params.madhab = adhan.Madhab.Shafi;
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(35.775, -78.6336),
-    date,
-    params,
-  );
+  const params = CalculationMethod.MuslimWorldLeague();
+  params.madhab = Madhab.Shafi;
+  const p = new PrayerTimes(new Coordinates(35.775, -78.6336), date, params);
   expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
     '5:35 AM',
   );
@@ -67,11 +64,7 @@ test('useing offsets to manually adjust prayer times', () => {
   params.adjustments.maghrib = 10;
   params.adjustments.isha = 10;
 
-  const p2 = new adhan.PrayerTimes(
-    new adhan.Coordinates(35.775, -78.6336),
-    date,
-    params,
-  );
+  const p2 = new PrayerTimes(new Coordinates(35.775, -78.6336), date, params);
   expect(moment(p2.fajr).tz('America/New_York').format('h:mm A')).toBe(
     '5:45 AM',
   );
@@ -95,10 +88,10 @@ test('useing offsets to manually adjust prayer times', () => {
 test('calculating prayer times using the Moonsighting Committee calculation method', () => {
   // Values from http://www.moonsighting.com/pray.php
   const date = new Date(2016, 0, 31);
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(35.775, -78.6336),
+  const p = new PrayerTimes(
+    new Coordinates(35.775, -78.6336),
     date,
-    adhan.CalculationMethod.MoonsightingCommittee(),
+    CalculationMethod.MoonsightingCommittee(),
   );
   expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
     '5:48 AM',
@@ -121,13 +114,9 @@ test('calculating prayer times using the Moonsighting Committee calculation meth
 test('calculating Moonsighting Committee prayer times at a high latitude location', () => {
   // Values from http://www.moonsighting.com/pray.php
   const date = new Date(2016, 0, 1);
-  const params = adhan.CalculationMethod.MoonsightingCommittee();
-  params.madhab = adhan.Madhab.Hanafi;
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(59.9094, 10.7349),
-    date,
-    params,
-  );
+  const params = CalculationMethod.MoonsightingCommittee();
+  params.madhab = Madhab.Hanafi;
+  const p = new PrayerTimes(new Coordinates(59.9094, 10.7349), date, params);
   expect(moment(p.fajr).tz('Europe/Oslo').format('h:mm A')).toBe('7:34 AM');
   expect(moment(p.sunrise).tz('Europe/Oslo').format('h:mm A')).toBe('9:19 AM');
   expect(moment(p.dhuhr).tz('Europe/Oslo').format('h:mm A')).toBe('12:25 PM');
@@ -138,90 +127,70 @@ test('calculating Moonsighting Committee prayer times at a high latitude locatio
 
 test('getting the time for a given prayer', () => {
   const date = new Date(2016, 6, 1);
-  const params = adhan.CalculationMethod.MuslimWorldLeague();
-  params.madhab = adhan.Madhab.Hanafi;
-  params.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle;
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(59.9094, 10.7349),
-    date,
-    params,
-  );
-  expect(p.timeForPrayer(adhan.Prayer.Fajr)).toBe(p.fajr);
-  expect(p.timeForPrayer(adhan.Prayer.Sunrise)).toBe(p.sunrise);
-  expect(p.timeForPrayer(adhan.Prayer.Dhuhr)).toBe(p.dhuhr);
-  expect(p.timeForPrayer(adhan.Prayer.Asr)).toBe(p.asr);
-  expect(p.timeForPrayer(adhan.Prayer.Maghrib)).toBe(p.maghrib);
-  expect(p.timeForPrayer(adhan.Prayer.Isha)).toBe(p.isha);
-  expect(p.timeForPrayer(adhan.Prayer.None)).toBeNull();
+  const params = CalculationMethod.MuslimWorldLeague();
+  params.madhab = Madhab.Hanafi;
+  params.highLatitudeRule = HighLatitudeRule.TwilightAngle;
+  const p = new PrayerTimes(new Coordinates(59.9094, 10.7349), date, params);
+  expect(p.timeForPrayer(Prayer.Fajr)).toBe(p.fajr);
+  expect(p.timeForPrayer(Prayer.Sunrise)).toBe(p.sunrise);
+  expect(p.timeForPrayer(Prayer.Dhuhr)).toBe(p.dhuhr);
+  expect(p.timeForPrayer(Prayer.Asr)).toBe(p.asr);
+  expect(p.timeForPrayer(Prayer.Maghrib)).toBe(p.maghrib);
+  expect(p.timeForPrayer(Prayer.Isha)).toBe(p.isha);
+  expect(p.timeForPrayer(Prayer.None)).toBeNull();
 });
 
 test('getting the current prayer', () => {
   const date = new Date(2015, 8, 1);
-  const params = adhan.CalculationMethod.Karachi();
-  params.madhab = adhan.Madhab.Hanafi;
-  params.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle;
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(33.720817, 73.090032),
+  const params = CalculationMethod.Karachi();
+  params.madhab = Madhab.Hanafi;
+  params.highLatitudeRule = HighLatitudeRule.TwilightAngle;
+  const p = new PrayerTimes(
+    new Coordinates(33.720817, 73.090032),
     date,
     params,
   );
-  expect(p.currentPrayer(dateByAddingSeconds(p.fajr, -1))).toBe(
-    adhan.Prayer.None,
-  );
-  expect(p.currentPrayer(p.fajr)).toBe(adhan.Prayer.Fajr);
-  expect(p.currentPrayer(dateByAddingSeconds(p.fajr, 1))).toBe(
-    adhan.Prayer.Fajr,
-  );
+  expect(p.currentPrayer(dateByAddingSeconds(p.fajr, -1))).toBe(Prayer.None);
+  expect(p.currentPrayer(p.fajr)).toBe(Prayer.Fajr);
+  expect(p.currentPrayer(dateByAddingSeconds(p.fajr, 1))).toBe(Prayer.Fajr);
   expect(p.currentPrayer(dateByAddingSeconds(p.sunrise, 1))).toBe(
-    adhan.Prayer.Sunrise,
+    Prayer.Sunrise,
   );
-  expect(p.currentPrayer(dateByAddingSeconds(p.dhuhr, 1))).toBe(
-    adhan.Prayer.Dhuhr,
-  );
-  expect(p.currentPrayer(dateByAddingSeconds(p.asr, 1))).toBe(adhan.Prayer.Asr);
+  expect(p.currentPrayer(dateByAddingSeconds(p.dhuhr, 1))).toBe(Prayer.Dhuhr);
+  expect(p.currentPrayer(dateByAddingSeconds(p.asr, 1))).toBe(Prayer.Asr);
   expect(p.currentPrayer(dateByAddingSeconds(p.maghrib, 1))).toBe(
-    adhan.Prayer.Maghrib,
+    Prayer.Maghrib,
   );
-  expect(p.currentPrayer(dateByAddingSeconds(p.isha, 1))).toBe(
-    adhan.Prayer.Isha,
-  );
+  expect(p.currentPrayer(dateByAddingSeconds(p.isha, 1))).toBe(Prayer.Isha);
 });
 
 test('getting the next prayer', () => {
   const date = new Date(2015, 8, 1);
-  const params = adhan.CalculationMethod.Karachi();
-  params.madhab = adhan.Madhab.Hanafi;
-  params.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle;
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(33.720817, 73.090032),
+  const params = CalculationMethod.Karachi();
+  params.madhab = Madhab.Hanafi;
+  params.highLatitudeRule = HighLatitudeRule.TwilightAngle;
+  const p = new PrayerTimes(
+    new Coordinates(33.720817, 73.090032),
     date,
     params,
   );
-  expect(p.nextPrayer(dateByAddingSeconds(p.fajr, -1))).toBe(adhan.Prayer.Fajr);
-  expect(p.nextPrayer(p.fajr)).toBe(adhan.Prayer.Sunrise);
-  expect(p.nextPrayer(dateByAddingSeconds(p.fajr, 1))).toBe(
-    adhan.Prayer.Sunrise,
-  );
-  expect(p.nextPrayer(dateByAddingSeconds(p.sunrise, 1))).toBe(
-    adhan.Prayer.Dhuhr,
-  );
-  expect(p.nextPrayer(dateByAddingSeconds(p.dhuhr, 1))).toBe(adhan.Prayer.Asr);
-  expect(p.nextPrayer(dateByAddingSeconds(p.asr, 1))).toBe(
-    adhan.Prayer.Maghrib,
-  );
-  expect(p.nextPrayer(dateByAddingSeconds(p.maghrib, 1))).toBe(
-    adhan.Prayer.Isha,
-  );
-  expect(p.nextPrayer(dateByAddingSeconds(p.isha, 1))).toBe(adhan.Prayer.None);
+  expect(p.nextPrayer(dateByAddingSeconds(p.fajr, -1))).toBe(Prayer.Fajr);
+  expect(p.nextPrayer(p.fajr)).toBe(Prayer.Sunrise);
+  expect(p.nextPrayer(dateByAddingSeconds(p.fajr, 1))).toBe(Prayer.Sunrise);
+  expect(p.nextPrayer(dateByAddingSeconds(p.sunrise, 1))).toBe(Prayer.Dhuhr);
+  expect(p.nextPrayer(dateByAddingSeconds(p.dhuhr, 1))).toBe(Prayer.Asr);
+  expect(p.nextPrayer(dateByAddingSeconds(p.asr, 1))).toBe(Prayer.Maghrib);
+  expect(p.nextPrayer(dateByAddingSeconds(p.maghrib, 1))).toBe(Prayer.Isha);
+  expect(p.nextPrayer(dateByAddingSeconds(p.isha, 1))).toBe(Prayer.None);
 });
 
 test('getting the current next prayer', () => {
   const date = new Date();
-  const params = adhan.CalculationMethod.Karachi();
-  params.madhab = adhan.Madhab.Hanafi;
-  params.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle;
-  const p = new adhan.PrayerTimes(
-    new adhan.Coordinates(33.720817, 73.090032),
+  const params = CalculationMethod.Karachi();
+  params.madhab = Madhab.Hanafi;
+  params.highLatitudeRule = HighLatitudeRule.TwilightAngle;
+  const p = new PrayerTimes(
+    new Coordinates(33.720817, 73.090032),
     date,
     params,
   );

--- a/test/dist.test.ts
+++ b/test/dist.test.ts
@@ -1,10 +1,12 @@
 import moment from 'moment-timezone';
-import CalculationMethod from '../src/CalculationMethod';
-import Coordinates from '../src/Coordinates';
-import HighLatitudeRule from '../src/HighLatitudeRule';
-import { Madhab } from '../src/Madhab';
-import Prayer from '../src/Prayer';
-import PrayerTimes from '../src/PrayerTimes';
+import {
+  CalculationMethod,
+  Coordinates,
+  HighLatitudeRule,
+  Madhab,
+  Prayer,
+  PrayerTimes,
+} from '../src/Adhan';
 
 function dateByAddingSeconds(date: Date, seconds: number) {
   return new Date(date.getTime() + seconds * 1000);

--- a/test/dist.test.ts
+++ b/test/dist.test.ts
@@ -1,12 +1,5 @@
+import * as adhan from '../src/Adhan';
 import moment from 'moment-timezone';
-import {
-  CalculationMethod,
-  Coordinates,
-  HighLatitudeRule,
-  Madhab,
-  Prayer,
-  PrayerTimes,
-} from '../src/Adhan';
 
 function dateByAddingSeconds(date: Date, seconds: number) {
   return new Date(date.getTime() + seconds * 1000);
@@ -14,9 +7,13 @@ function dateByAddingSeconds(date: Date, seconds: number) {
 
 test('calculating prayer times', () => {
   const date = new Date(2015, 6, 12);
-  const params = CalculationMethod.NorthAmerica();
-  params.madhab = Madhab.Hanafi;
-  const p = new PrayerTimes(new Coordinates(35.775, -78.6336), date, params);
+  const params = adhan.CalculationMethod.NorthAmerica();
+  params.madhab = adhan.Madhab.Hanafi;
+  const p = new adhan.PrayerTimes(
+    new adhan.Coordinates(35.775, -78.6336),
+    date,
+    params,
+  );
 
   expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
     '4:42 AM',
@@ -39,9 +36,13 @@ test('calculating prayer times', () => {
 
 test('useing offsets to manually adjust prayer times', () => {
   const date = new Date(2015, 11, 1);
-  const params = CalculationMethod.MuslimWorldLeague();
-  params.madhab = Madhab.Shafi;
-  const p = new PrayerTimes(new Coordinates(35.775, -78.6336), date, params);
+  const params = adhan.CalculationMethod.MuslimWorldLeague();
+  params.madhab = adhan.Madhab.Shafi;
+  const p = new adhan.PrayerTimes(
+    new adhan.Coordinates(35.775, -78.6336),
+    date,
+    params,
+  );
   expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
     '5:35 AM',
   );
@@ -66,7 +67,11 @@ test('useing offsets to manually adjust prayer times', () => {
   params.adjustments.maghrib = 10;
   params.adjustments.isha = 10;
 
-  const p2 = new PrayerTimes(new Coordinates(35.775, -78.6336), date, params);
+  const p2 = new adhan.PrayerTimes(
+    new adhan.Coordinates(35.775, -78.6336),
+    date,
+    params,
+  );
   expect(moment(p2.fajr).tz('America/New_York').format('h:mm A')).toBe(
     '5:45 AM',
   );
@@ -90,10 +95,10 @@ test('useing offsets to manually adjust prayer times', () => {
 test('calculating prayer times using the Moonsighting Committee calculation method', () => {
   // Values from http://www.moonsighting.com/pray.php
   const date = new Date(2016, 0, 31);
-  const p = new PrayerTimes(
-    new Coordinates(35.775, -78.6336),
+  const p = new adhan.PrayerTimes(
+    new adhan.Coordinates(35.775, -78.6336),
     date,
-    CalculationMethod.MoonsightingCommittee(),
+    adhan.CalculationMethod.MoonsightingCommittee(),
   );
   expect(moment(p.fajr).tz('America/New_York').format('h:mm A')).toBe(
     '5:48 AM',
@@ -116,9 +121,13 @@ test('calculating prayer times using the Moonsighting Committee calculation meth
 test('calculating Moonsighting Committee prayer times at a high latitude location', () => {
   // Values from http://www.moonsighting.com/pray.php
   const date = new Date(2016, 0, 1);
-  const params = CalculationMethod.MoonsightingCommittee();
-  params.madhab = Madhab.Hanafi;
-  const p = new PrayerTimes(new Coordinates(59.9094, 10.7349), date, params);
+  const params = adhan.CalculationMethod.MoonsightingCommittee();
+  params.madhab = adhan.Madhab.Hanafi;
+  const p = new adhan.PrayerTimes(
+    new adhan.Coordinates(59.9094, 10.7349),
+    date,
+    params,
+  );
   expect(moment(p.fajr).tz('Europe/Oslo').format('h:mm A')).toBe('7:34 AM');
   expect(moment(p.sunrise).tz('Europe/Oslo').format('h:mm A')).toBe('9:19 AM');
   expect(moment(p.dhuhr).tz('Europe/Oslo').format('h:mm A')).toBe('12:25 PM');
@@ -129,70 +138,90 @@ test('calculating Moonsighting Committee prayer times at a high latitude locatio
 
 test('getting the time for a given prayer', () => {
   const date = new Date(2016, 6, 1);
-  const params = CalculationMethod.MuslimWorldLeague();
-  params.madhab = Madhab.Hanafi;
-  params.highLatitudeRule = HighLatitudeRule.TwilightAngle;
-  const p = new PrayerTimes(new Coordinates(59.9094, 10.7349), date, params);
-  expect(p.timeForPrayer(Prayer.Fajr)).toBe(p.fajr);
-  expect(p.timeForPrayer(Prayer.Sunrise)).toBe(p.sunrise);
-  expect(p.timeForPrayer(Prayer.Dhuhr)).toBe(p.dhuhr);
-  expect(p.timeForPrayer(Prayer.Asr)).toBe(p.asr);
-  expect(p.timeForPrayer(Prayer.Maghrib)).toBe(p.maghrib);
-  expect(p.timeForPrayer(Prayer.Isha)).toBe(p.isha);
-  expect(p.timeForPrayer(Prayer.None)).toBeNull();
+  const params = adhan.CalculationMethod.MuslimWorldLeague();
+  params.madhab = adhan.Madhab.Hanafi;
+  params.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle;
+  const p = new adhan.PrayerTimes(
+    new adhan.Coordinates(59.9094, 10.7349),
+    date,
+    params,
+  );
+  expect(p.timeForPrayer(adhan.Prayer.Fajr)).toBe(p.fajr);
+  expect(p.timeForPrayer(adhan.Prayer.Sunrise)).toBe(p.sunrise);
+  expect(p.timeForPrayer(adhan.Prayer.Dhuhr)).toBe(p.dhuhr);
+  expect(p.timeForPrayer(adhan.Prayer.Asr)).toBe(p.asr);
+  expect(p.timeForPrayer(adhan.Prayer.Maghrib)).toBe(p.maghrib);
+  expect(p.timeForPrayer(adhan.Prayer.Isha)).toBe(p.isha);
+  expect(p.timeForPrayer(adhan.Prayer.None)).toBeNull();
 });
 
 test('getting the current prayer', () => {
   const date = new Date(2015, 8, 1);
-  const params = CalculationMethod.Karachi();
-  params.madhab = Madhab.Hanafi;
-  params.highLatitudeRule = HighLatitudeRule.TwilightAngle;
-  const p = new PrayerTimes(
-    new Coordinates(33.720817, 73.090032),
+  const params = adhan.CalculationMethod.Karachi();
+  params.madhab = adhan.Madhab.Hanafi;
+  params.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle;
+  const p = new adhan.PrayerTimes(
+    new adhan.Coordinates(33.720817, 73.090032),
     date,
     params,
   );
-  expect(p.currentPrayer(dateByAddingSeconds(p.fajr, -1))).toBe(Prayer.None);
-  expect(p.currentPrayer(p.fajr)).toBe(Prayer.Fajr);
-  expect(p.currentPrayer(dateByAddingSeconds(p.fajr, 1))).toBe(Prayer.Fajr);
+  expect(p.currentPrayer(dateByAddingSeconds(p.fajr, -1))).toBe(
+    adhan.Prayer.None,
+  );
+  expect(p.currentPrayer(p.fajr)).toBe(adhan.Prayer.Fajr);
+  expect(p.currentPrayer(dateByAddingSeconds(p.fajr, 1))).toBe(
+    adhan.Prayer.Fajr,
+  );
   expect(p.currentPrayer(dateByAddingSeconds(p.sunrise, 1))).toBe(
-    Prayer.Sunrise,
+    adhan.Prayer.Sunrise,
   );
-  expect(p.currentPrayer(dateByAddingSeconds(p.dhuhr, 1))).toBe(Prayer.Dhuhr);
-  expect(p.currentPrayer(dateByAddingSeconds(p.asr, 1))).toBe(Prayer.Asr);
+  expect(p.currentPrayer(dateByAddingSeconds(p.dhuhr, 1))).toBe(
+    adhan.Prayer.Dhuhr,
+  );
+  expect(p.currentPrayer(dateByAddingSeconds(p.asr, 1))).toBe(adhan.Prayer.Asr);
   expect(p.currentPrayer(dateByAddingSeconds(p.maghrib, 1))).toBe(
-    Prayer.Maghrib,
+    adhan.Prayer.Maghrib,
   );
-  expect(p.currentPrayer(dateByAddingSeconds(p.isha, 1))).toBe(Prayer.Isha);
+  expect(p.currentPrayer(dateByAddingSeconds(p.isha, 1))).toBe(
+    adhan.Prayer.Isha,
+  );
 });
 
 test('getting the next prayer', () => {
   const date = new Date(2015, 8, 1);
-  const params = CalculationMethod.Karachi();
-  params.madhab = Madhab.Hanafi;
-  params.highLatitudeRule = HighLatitudeRule.TwilightAngle;
-  const p = new PrayerTimes(
-    new Coordinates(33.720817, 73.090032),
+  const params = adhan.CalculationMethod.Karachi();
+  params.madhab = adhan.Madhab.Hanafi;
+  params.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle;
+  const p = new adhan.PrayerTimes(
+    new adhan.Coordinates(33.720817, 73.090032),
     date,
     params,
   );
-  expect(p.nextPrayer(dateByAddingSeconds(p.fajr, -1))).toBe(Prayer.Fajr);
-  expect(p.nextPrayer(p.fajr)).toBe(Prayer.Sunrise);
-  expect(p.nextPrayer(dateByAddingSeconds(p.fajr, 1))).toBe(Prayer.Sunrise);
-  expect(p.nextPrayer(dateByAddingSeconds(p.sunrise, 1))).toBe(Prayer.Dhuhr);
-  expect(p.nextPrayer(dateByAddingSeconds(p.dhuhr, 1))).toBe(Prayer.Asr);
-  expect(p.nextPrayer(dateByAddingSeconds(p.asr, 1))).toBe(Prayer.Maghrib);
-  expect(p.nextPrayer(dateByAddingSeconds(p.maghrib, 1))).toBe(Prayer.Isha);
-  expect(p.nextPrayer(dateByAddingSeconds(p.isha, 1))).toBe(Prayer.None);
+  expect(p.nextPrayer(dateByAddingSeconds(p.fajr, -1))).toBe(adhan.Prayer.Fajr);
+  expect(p.nextPrayer(p.fajr)).toBe(adhan.Prayer.Sunrise);
+  expect(p.nextPrayer(dateByAddingSeconds(p.fajr, 1))).toBe(
+    adhan.Prayer.Sunrise,
+  );
+  expect(p.nextPrayer(dateByAddingSeconds(p.sunrise, 1))).toBe(
+    adhan.Prayer.Dhuhr,
+  );
+  expect(p.nextPrayer(dateByAddingSeconds(p.dhuhr, 1))).toBe(adhan.Prayer.Asr);
+  expect(p.nextPrayer(dateByAddingSeconds(p.asr, 1))).toBe(
+    adhan.Prayer.Maghrib,
+  );
+  expect(p.nextPrayer(dateByAddingSeconds(p.maghrib, 1))).toBe(
+    adhan.Prayer.Isha,
+  );
+  expect(p.nextPrayer(dateByAddingSeconds(p.isha, 1))).toBe(adhan.Prayer.None);
 });
 
 test('getting the current next prayer', () => {
   const date = new Date();
-  const params = CalculationMethod.Karachi();
-  params.madhab = Madhab.Hanafi;
-  params.highLatitudeRule = HighLatitudeRule.TwilightAngle;
-  const p = new PrayerTimes(
-    new Coordinates(33.720817, 73.090032),
+  const params = adhan.CalculationMethod.Karachi();
+  params.madhab = adhan.Madhab.Hanafi;
+  params.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle;
+  const p = new adhan.PrayerTimes(
+    new adhan.Coordinates(33.720817, 73.090032),
     date,
     params,
   );

--- a/test/sunnah.test.ts
+++ b/test/sunnah.test.ts
@@ -1,23 +1,27 @@
-import adhan from '../src/Adhan';
 import moment from 'moment-timezone';
+import CalculationMethod from '../src/CalculationMethod';
+import Coordinates from '../src/Coordinates';
+import HighLatitudeRule from '../src/HighLatitudeRule';
+import PrayerTimes from '../src/PrayerTimes';
+import SunnahTimes from '../src/SunnahTimes';
 
 test('getting sunnah times for the New York timezone', () => {
-  const coords = new adhan.Coordinates(35.775, -78.6336);
-  const params = adhan.CalculationMethod.NorthAmerica();
+  const coords = new Coordinates(35.775, -78.6336);
+  const params = CalculationMethod.NorthAmerica();
 
   const date1 = new Date(2015, 6, 12);
-  const p1 = new adhan.PrayerTimes(coords, date1, params);
+  const p1 = new PrayerTimes(coords, date1, params);
   expect(
     moment(p1.maghrib).tz('America/New_York').format('M/D/YY, h:mm A'),
   ).toBe('7/12/15, 8:32 PM');
 
   const date2 = new Date(2015, 6, 13);
-  const p2 = new adhan.PrayerTimes(coords, date2, params);
+  const p2 = new PrayerTimes(coords, date2, params);
   expect(moment(p2.fajr).tz('America/New_York').format('M/D/YY, h:mm A')).toBe(
     '7/13/15, 4:43 AM',
   );
 
-  const sunnah = new adhan.SunnahTimes(p1);
+  const sunnah = new SunnahTimes(p1);
   expect(
     moment(sunnah.middleOfTheNight)
       .tz('America/New_York')
@@ -31,22 +35,22 @@ test('getting sunnah times for the New York timezone', () => {
 });
 
 test('getting sunnah times for the London timezone', () => {
-  const coords = new adhan.Coordinates(51.5074, -0.1278);
-  const params = adhan.CalculationMethod.MoonsightingCommittee();
+  const coords = new Coordinates(51.5074, -0.1278);
+  const params = CalculationMethod.MoonsightingCommittee();
 
   const date1 = new Date(2016, 11, 31);
-  const p1 = new adhan.PrayerTimes(coords, date1, params);
+  const p1 = new PrayerTimes(coords, date1, params);
   expect(moment(p1.maghrib).tz('Europe/London').format('M/D/YY, h:mm A')).toBe(
     '12/31/16, 4:04 PM',
   );
 
   const date2 = new Date(2017, 0, 1);
-  const p2 = new adhan.PrayerTimes(coords, date2, params);
+  const p2 = new PrayerTimes(coords, date2, params);
   expect(moment(p2.fajr).tz('Europe/London').format('M/D/YY, h:mm A')).toBe(
     '1/1/17, 6:25 AM',
   );
 
-  const sunnah = new adhan.SunnahTimes(p1);
+  const sunnah = new SunnahTimes(p1);
   expect(
     moment(sunnah.middleOfTheNight)
       .tz('Europe/London')
@@ -60,23 +64,23 @@ test('getting sunnah times for the London timezone', () => {
 });
 
 test('getting sunnah times for the Oslo timezone', () => {
-  const coords = new adhan.Coordinates(59.9094, 10.7349);
-  const params = adhan.CalculationMethod.MuslimWorldLeague();
-  params.highLatitudeRule = adhan.HighLatitudeRule.MiddleOfTheNight;
+  const coords = new Coordinates(59.9094, 10.7349);
+  const params = CalculationMethod.MuslimWorldLeague();
+  params.highLatitudeRule = HighLatitudeRule.MiddleOfTheNight;
 
   const date1 = new Date(2016, 6, 1);
-  const p1 = new adhan.PrayerTimes(coords, date1, params);
+  const p1 = new PrayerTimes(coords, date1, params);
   expect(moment(p1.maghrib).tz('Europe/Oslo').format('M/D/YY, h:mm A')).toBe(
     '7/1/16, 10:41 PM',
   );
 
   const date2 = new Date(2016, 6, 2);
-  const p2 = new adhan.PrayerTimes(coords, date2, params);
+  const p2 = new PrayerTimes(coords, date2, params);
   expect(moment(p2.fajr).tz('Europe/Oslo').format('M/D/YY, h:mm A')).toBe(
     '7/2/16, 1:20 AM',
   );
 
-  const sunnah = new adhan.SunnahTimes(p1);
+  const sunnah = new SunnahTimes(p1);
   expect(
     moment(sunnah.middleOfTheNight).tz('Europe/Oslo').format('M/D/YY, h:mm A'),
   ).toBe('7/2/16, 12:01 AM');
@@ -88,11 +92,11 @@ test('getting sunnah times for the Oslo timezone', () => {
 });
 
 test('getting sunnah times for US DST change', () => {
-  const coords = new adhan.Coordinates(37.7749, -122.4194);
-  const params = adhan.CalculationMethod.NorthAmerica();
+  const coords = new Coordinates(37.7749, -122.4194);
+  const params = CalculationMethod.NorthAmerica();
 
   const date1 = new Date(2017, 2, 11);
-  const p1 = new adhan.PrayerTimes(coords, date1, params);
+  const p1 = new PrayerTimes(coords, date1, params);
   expect(
     moment(p1.fajr).tz('America/Los_Angeles').format('M/D/YY, h:mm A'),
   ).toBe('3/11/17, 5:14 AM');
@@ -101,7 +105,7 @@ test('getting sunnah times for US DST change', () => {
   ).toBe('3/11/17, 6:13 PM');
 
   const date2 = new Date(2017, 2, 12);
-  const p2 = new adhan.PrayerTimes(coords, date2, params);
+  const p2 = new PrayerTimes(coords, date2, params);
   expect(
     moment(p2.fajr).tz('America/Los_Angeles').format('M/D/YY, h:mm A'),
   ).toBe('3/12/17, 6:13 AM');
@@ -109,7 +113,7 @@ test('getting sunnah times for US DST change', () => {
     moment(p2.maghrib).tz('America/Los_Angeles').format('M/D/YY, h:mm A'),
   ).toBe('3/12/17, 7:14 PM');
 
-  const sunnah = new adhan.SunnahTimes(p1);
+  const sunnah = new SunnahTimes(p1);
   expect(
     moment(sunnah.middleOfTheNight)
       .tz('America/Los_Angeles')
@@ -123,12 +127,12 @@ test('getting sunnah times for US DST change', () => {
 });
 
 test('getting sunnah times for Europe DST change', () => {
-  const coords = new adhan.Coordinates(48.8566, 2.3522);
-  const params = adhan.CalculationMethod.MuslimWorldLeague();
-  params.highLatitudeRule = adhan.HighLatitudeRule.SeventhOfTheNight;
+  const coords = new Coordinates(48.8566, 2.3522);
+  const params = CalculationMethod.MuslimWorldLeague();
+  params.highLatitudeRule = HighLatitudeRule.SeventhOfTheNight;
 
   const date1 = new Date(2015, 9, 24);
-  const p1 = new adhan.PrayerTimes(coords, date1, params);
+  const p1 = new PrayerTimes(coords, date1, params);
   expect(moment(p1.fajr).tz('Europe/Paris').format('M/D/YY, h:mm A')).toBe(
     '10/24/15, 6:38 AM',
   );
@@ -137,7 +141,7 @@ test('getting sunnah times for Europe DST change', () => {
   );
 
   const date2 = new Date(2015, 9, 25);
-  const p2 = new adhan.PrayerTimes(coords, date2, params);
+  const p2 = new PrayerTimes(coords, date2, params);
   expect(moment(p2.fajr).tz('Europe/Paris').format('M/D/YY, h:mm A')).toBe(
     '10/25/15, 5:40 AM',
   );
@@ -145,7 +149,7 @@ test('getting sunnah times for Europe DST change', () => {
     '10/25/15, 5:43 PM',
   );
 
-  const sunnah = new adhan.SunnahTimes(p1);
+  const sunnah = new SunnahTimes(p1);
   expect(
     moment(sunnah.middleOfTheNight).tz('Europe/Paris').format('M/D/YY, h:mm A'),
   ).toBe('10/25/15, 12:43 AM');

--- a/test/times.test.ts
+++ b/test/times.test.ts
@@ -1,8 +1,12 @@
 /* eslint-disable complexity */
 import fs from 'fs';
-import adhan from '../src/Adhan';
 import moment from 'moment-timezone';
+import CalculationMethod from '../src/CalculationMethod';
 import CalculationParameters from '../src/CalculationParameters';
+import Coordinates from '../src/Coordinates';
+import HighLatitudeRule from '../src/HighLatitudeRule';
+import { Madhab } from '../src/Madhab';
+import PrayerTimes from '../src/PrayerTimes';
 
 function parseParams(data: {
   method: string;
@@ -13,47 +17,47 @@ function parseParams(data: {
 
   const method = data['method'];
   if (method === 'MuslimWorldLeague') {
-    params = adhan.CalculationMethod.MuslimWorldLeague();
+    params = CalculationMethod.MuslimWorldLeague();
   } else if (method === 'Egyptian') {
-    params = adhan.CalculationMethod.Egyptian();
+    params = CalculationMethod.Egyptian();
   } else if (method === 'Karachi') {
-    params = adhan.CalculationMethod.Karachi();
+    params = CalculationMethod.Karachi();
   } else if (method === 'UmmAlQura') {
-    params = adhan.CalculationMethod.UmmAlQura();
+    params = CalculationMethod.UmmAlQura();
   } else if (method === 'Dubai') {
-    params = adhan.CalculationMethod.Dubai();
+    params = CalculationMethod.Dubai();
   } else if (method === 'MoonsightingCommittee') {
-    params = adhan.CalculationMethod.MoonsightingCommittee();
+    params = CalculationMethod.MoonsightingCommittee();
   } else if (method === 'NorthAmerica') {
-    params = adhan.CalculationMethod.NorthAmerica();
+    params = CalculationMethod.NorthAmerica();
   } else if (method === 'Kuwait') {
-    params = adhan.CalculationMethod.Kuwait();
+    params = CalculationMethod.Kuwait();
   } else if (method === 'Qatar') {
-    params = adhan.CalculationMethod.Qatar();
+    params = CalculationMethod.Qatar();
   } else if (method === 'Singapore') {
-    params = adhan.CalculationMethod.Singapore();
+    params = CalculationMethod.Singapore();
   } else if (method === 'Turkey') {
-    params = adhan.CalculationMethod.Turkey();
+    params = CalculationMethod.Turkey();
   } else if (method === 'Tehran') {
-    params = adhan.CalculationMethod.Tehran();
+    params = CalculationMethod.Tehran();
   } else {
-    params = adhan.CalculationMethod.Other();
+    params = CalculationMethod.Other();
   }
 
   const madhab = data['madhab'];
   if (madhab === 'Shafi') {
-    params.madhab = adhan.Madhab.Shafi;
+    params.madhab = Madhab.Shafi;
   } else if (madhab === 'Hanafi') {
-    params.madhab = adhan.Madhab.Hanafi;
+    params.madhab = Madhab.Hanafi;
   }
 
   const highLatRule = data['highLatitudeRule'];
   if (highLatRule === 'SeventhOfTheNight') {
-    params.highLatitudeRule = adhan.HighLatitudeRule.SeventhOfTheNight;
+    params.highLatitudeRule = HighLatitudeRule.SeventhOfTheNight;
   } else if (highLatRule === 'TwilightAngle') {
-    params.highLatitudeRule = adhan.HighLatitudeRule.TwilightAngle;
+    params.highLatitudeRule = HighLatitudeRule.TwilightAngle;
   } else {
-    params.highLatitudeRule = adhan.HighLatitudeRule.MiddleOfTheNight;
+    params.highLatitudeRule = HighLatitudeRule.MiddleOfTheNight;
   }
 
   return params;
@@ -119,7 +123,7 @@ fs.readdirSync('Shared/Times').forEach(function (filename) {
   test(`compare calculated times against the prayer times in ${filename}`, () => {
     const file_contents = fs.readFileSync('Shared/Times/' + filename);
     const data: TestFile = JSON.parse(file_contents.toString());
-    const coordinates = new adhan.Coordinates(
+    const coordinates = new Coordinates(
       data['params']['latitude'],
       data['params']['longitude'],
     );
@@ -127,7 +131,7 @@ fs.readdirSync('Shared/Times').forEach(function (filename) {
     const variance = data['variance'] || 0;
     data['times'].forEach(function (time) {
       const date = moment(time['date'], 'YYYY-MM-DD').toDate();
-      const p = new adhan.PrayerTimes(coordinates, date, params);
+      const p = new PrayerTimes(coordinates, date, params);
 
       const testFajr = moment
         .tz(


### PR DESCRIPTION
As-is you cannot `var adhan = require('adhan');` and have the same functionality as before. With this MR, commonjs usage will remain the same.