### PR TITLE
Fix incorrect types generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:esm": "cross-env BABEL_ENV=esmUnbundled babel src --extensions '.ts' --out-dir 'lib/esm' --source-maps",
     "build:cjs": "cross-env BABEL_ENV=cjs babel src --extensions '.ts' --out-dir 'lib/cjs' --source-maps",
     "build:bundles": "cross-env BABEL_ENV=esmBundled rollup -c",
-    "build:types": "tsc --emitDeclarationOnly",
+    "build:types": "tsc -b tsconfig.types.json",
     "lint": "run-p -l lint:*",
     "lint:eslint": "eslint --max-warnings=0 .",
     "lint:tsc": "tsc --noEmit",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "@tsconfig/node12/tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
-    "declarationDir": "lib/types/",
     "strict": true
   },
   "include": ["src/**/*.ts", "test/**/*.ts"],

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "lib/types/",
+    "emitDeclarationOnly": true
+  },
+  "exclude": ["test/**/*.ts"]
+}


### PR DESCRIPTION
fixes #113

Was previously generating types for both `src/` and `tests/` resulting in the desired types at `lib/types/src/...` instead of `lib/types/...`. Using a custom tsconfig for types generation that resolves this.