### PR TITLE
docs(examples): modernized example and readme

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,12 +1,16 @@
 ## Upgrading from 3.0.0 to 4.0.0
-Upgrading to 4.0.0 introduces breaking API changes. 
 
-The `adhan.Date.formattedTime` convenience function is no longer provided by this library. 
-These functions obscure the difficulty in dealing with Daylight Savings Time
-and other timezone issues.
+Upgrading to 4.0.0 introduces breaking API changes.
 
-Instead you should use a timezone aware date formatting library like [moment](https://momentjs.com).
- 
+The `adhan.Date.formattedTime` convenience function is no longer provided by this library.
+These utility functions obscure the complexity of handling time zones and Daylight Saving Time (DST) shifts.
+
+When formatting your results, never assume the user's current device timezone matches the timezone of the coordinates you passed to Adhan.
+
+If a user living in New York calculates prayer times for London, using the device's default locale settings will incorrectly display London's times using New York's UTC offset. To prevent broken schedules and skipped calculations during seasonal DST transitions, you must explicitly bind your formatting to a specific, location-aware Time Zone Identifier (like Europe/London or America/New_York) that mirrors your geographic coordinates.
+
+We recommend utilizing the native Temporal API (along with an environment polyfill if required) to cleanly handle this timezone mapping.
+
 **Before**:
 
 ```js
@@ -16,5 +20,12 @@ adhan.Date.formattedTime(prayerTimes.fajr); // no longer available
 **After**:
 
 ```js
-moment(prayerTimes.fajr).tz('America/New_York').format('h:mm A'); // Recommended method
+// Recommended modern method using native Temporal
+Temporal.Instant.fromEpochMilliseconds(prayerTimes.fajr.getTime())
+  .toZonedDateTimeISO('America/New_York')
+  .toLocaleString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
 ```

--- a/README.md
+++ b/README.md
@@ -16,12 +16,32 @@ Adhan was designed to work in both the browser and NodeJS applications.
 
 We provide both ESM and UMD bundles for use in the browser.
 
-Download the latest release and check under `package/lib/bundles`.
+ES Modules:
 
 ```html
-<script src="adhan.umd.min.js"></script>
+<script type="module">
+  import {
+    Coordinates,
+    CalculationMethod,
+    PrayerTimes,
+  } from 'https://unpkg.com/adhan/lib/bundles/adhan.esm.js';
+
+  const coordinates = new Coordinates(35.789751, -78.691249);
+  const params = CalculationMethod.MoonsightingCommittee();
+  const prayerTimes = new PrayerTimes(coordinates, new Date(), params);
+
+  console.log(prayerTimes.fajr);
+</script>
+```
+
+UMD global:
+
+```html
+<script src="https://unpkg.com/adhan/lib/bundles/adhan.umd.min.js"></script>
 <script>
-  var prayerTimes = new adhan.PrayerTimes(coordinates, date, params);
+  const coordinates = new adhan.Coordinates(35.789751, -78.691249);
+  const params = adhan.CalculationMethod.MoonsightingCommittee();
+  const prayerTimes = new adhan.PrayerTimes(coordinates, new Date(), params);
 </script>
 ```
 
@@ -33,26 +53,29 @@ Both CommonJS and ES Module libraries are provided.
 npm install adhan
 ```
 
-CommonJS:
-
-```js
-const adhan = require('adhan');
-const prayerTimes = new adhan.PrayerTimes(coordinates, date, params);
-```
-
 ES Modules:
 
 ```js
 import { Coordinates, CalculationMethod, PrayerTimes } from 'adhan';
-const coordinates = new Coordinates(35.7897507, -78.6912485);
+
+const coordinates = new Coordinates(35.789751, -78.691249);
 const params = CalculationMethod.MoonsightingCommittee();
-const date = new Date(2022, 3, 20);
-const prayerTimes = new PrayerTimes(coordinates, date, params);
+const prayerTimes = new PrayerTimes(coordinates, new Date(), params);
+
+console.log(prayerTimes.fajr);
 ```
 
-## Migration
+CommonJS:
 
-Migrating from version 3.x? Read the [migration guide](MIGRATION.md)
+```js
+const adhan = require('adhan');
+
+const coordinates = new adhan.Coordinates(35.789751, -78.691249);
+const params = adhan.CalculationMethod.MoonsightingCommittee();
+const prayerTimes = new adhan.PrayerTimes(coordinates, new Date(), params);
+
+console.log(prayerTimes.fajr);
+```
 
 ## Usage
 
@@ -105,28 +128,6 @@ date formatting library like [moment](https://momentjs.com/docs/).
 moment(prayerTimes.fajr).tz('America/New_York').format('h:mm A');
 ```
 
-### Full Example
-
-```ts
-import {
-  Coordinates,
-  CalculationMethod,
-  PrayerTimes,
-  SunnahTimes,
-  Prayer,
-  Qibla,
-} from 'adhan';
-import moment from 'moment-timezone';
-
-const coordinates = new Coordinates(35.7897507, -78.6912485);
-const params = CalculationMethod.MoonsightingCommittee();
-const date = new Date();
-const prayerTimes = new PrayerTimes(coordinates, date, params);
-const sunnahTimes = new SunnahTimes(prayerTimes);
-```
-
-[![Edit Adhan Example](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/adhan-example-88v549?fontsize=14&hidenavigation=1&theme=dark)
-
 ### Convenience Utilities
 
 The `PrayerTimes` object has functions for getting the current prayer and the next prayer. You can also get the time for a specified prayer, making it
@@ -162,6 +163,14 @@ Get the direction, in degrees from North, of the Qibla from a given set of coord
 var coordinates = new Coordinates(35.78056, -78.6389);
 var qiblaDirection = Qibla(coordinates);
 ```
+
+### Full Example
+
+See `example.html` for a full browser based example.
+
+## Migration
+
+Migrating from version 3.x? Read the [migration guide](MIGRATION.md)
 
 ## Contributing
 

--- a/example.html
+++ b/example.html
@@ -1,55 +1,136 @@
-<html>
+<!doctype html>
+<html lang="en">
   <head>
+    <meta charset="UTF-8" />
+    <title>Adhan JS Example</title>
     <script src="lib/bundles/adhan.umd.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.28/moment-timezone-with-data-10-year-range.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@js-temporal/polyfill@0.4.4/dist/index.umd.production.min.js"></script>
+
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 400px;
+        margin: 40px auto;
+        padding: 20px;
+        line-height: 1.6;
+      }
+      .row {
+        display: flex;
+        justify-content: space-between;
+        border-bottom: 1px solid #eee;
+        padding: 6px 0;
+      }
+      .label {
+        font-weight: bold;
+      }
+      .meta {
+        color: #666;
+        font-size: 0.9rem;
+        margin-bottom: 20px;
+      }
+    </style>
   </head>
-
   <body>
-    <pre><script type="text/javascript">
+    <h2>Raleigh, NC</h2>
+    <div class="meta" id="meta-display"></div>
 
-        function prayerName(prayer) {
-            if (prayer == adhan.Prayer.Fajr) {
-                return "Fajr";
-            } else if (prayer == adhan.Prayer.Sunrise) {
-                return "Sunrise";
-            } else if (prayer == adhan.Prayer.Dhuhr) {
-                return "Dhuhr";
-            } else if (prayer == adhan.Prayer.Asr) {
-                return "Asr";
-            } else if (prayer == adhan.Prayer.Maghrib) {
-                return "Maghrib";
-            } else if (prayer == adhan.Prayer.Isha) {
-                return "Isha";
-            } else if (prayer == adhan.Prayer.None) {
-                return "None";
-            }
-        }
+    <div id="timetable">
+      <div class="row">
+        <span class="label">Fajr</span><span id="fajr"></span>
+      </div>
+      <div class="row">
+        <span class="label">Sunrise</span><span id="sunrise"></span>
+      </div>
+      <div class="row">
+        <span class="label">Dhuhr</span><span id="dhuhr"></span>
+      </div>
+      <div class="row">
+        <span class="label">Asr</span><span id="asr"></span>
+      </div>
+      <div class="row">
+        <span class="label">Maghrib</span><span id="maghrib"></span>
+      </div>
+      <div class="row">
+        <span class="label">Isha</span><span id="isha"></span>
+      </div>
+      <br />
+      <div class="row">
+        <span class="label">Middle of Night</span><span id="midnight"></span>
+      </div>
+      <div class="row">
+        <span class="label">Last Third of Night</span
+        ><span id="last-third"></span>
+      </div>
+      <br />
+      <div class="row" style="text-transform: capitalize">
+        <span class="label">Current Prayer</span
+        ><span id="current-prayer"></span>
+      </div>
+      <div class="row" style="text-transform: capitalize">
+        <span class="label">Next Prayer</span><span id="next-prayer"></span>
+      </div>
+    </div>
 
-        const coordinates = new adhan.Coordinates(35.7897507, -78.6912485);
-        const params = adhan.CalculationMethod.MoonsightingCommittee();
-        const date = new Date(2022, 3, 20);
+    <script>
+      const coordinates = new adhan.Coordinates(35.7897507, -78.6912485);
+      const params = adhan.CalculationMethod.NorthAmerica();
+      const timeZone = 'America/New_York';
 
-        var prayerTimes = new adhan.PrayerTimes(coordinates, date, params);
+      const instant = Temporal.Now.instant();
+      const zonedDateTime = instant.toZonedDateTimeISO(timeZone);
 
-        var sunnahTimes = new adhan.SunnahTimes(prayerTimes);
+      const prayerTimes = new adhan.PrayerTimes(
+        coordinates,
+        new Date(instant.epochMilliseconds),
+        params,
+      );
+      const sunnahTimes = new adhan.SunnahTimes(prayerTimes);
 
-        document.write('Raleigh, NC - Moonsighting Committee\n');
-        document.write(`Prayer times for ${moment(date).format('MMMM DD, YYYY')}\n`);
-        document.write(`Fajr: ${moment(prayerTimes.fajr).tz('America/New_York').format('MMMM DD, YYYY h:mm A')}\n`);
-        document.write(`Sunrise: ${moment(prayerTimes.sunrise).tz('America/New_York').format('MMMM DD, YYYY h:mm A')}\n`);
-        document.write(`Dhuhr: ${moment(prayerTimes.dhuhr).tz('America/New_York').format('MMMM DD, YYYY h:mm A')}\n`);
-        document.write(`Asr: ${moment(prayerTimes.asr).tz('America/New_York').format('MMMM DD, YYYY h:mm A')}\n`);
-        document.write(`Maghrib: ${moment(prayerTimes.maghrib).tz('America/New_York').format('MMMM DD, YYYY h:mm A')}\n`);
-        document.write(`Isha: ${moment(prayerTimes.isha).tz('America/New_York').format('MMMM DD, YYYY h:mm A')}\n`);
+      const format = (jsDate) => {
+        if (!jsDate) return '--:--';
+        return Temporal.Instant.fromEpochMilliseconds(jsDate.getTime())
+          .toZonedDateTimeISO(timeZone)
+          .toLocaleString('en-US', {
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true,
+          });
+      };
 
-        document.write(`middle of the night: ${moment(sunnahTimes.middleOfTheNight).tz('America/New_York').format('MMMM DD, YYYY h:mm A')}\n`);
-        document.write(`last third of the night: ${moment(sunnahTimes.lastThirdOfTheNight).tz('America/New_York').format('MMMM DD, YYYY h:mm A')}\n\n`);
+      // Meta display (Date & Qibla)
+      const dateString = zonedDateTime.toLocaleString('en-US', {
+        dateStyle: 'full',
+      });
+      document.getElementById('meta-display').innerHTML =
+        `${dateString}<br>Qibla: ${adhan.Qibla(coordinates).toFixed(2)}°`;
 
-        document.write(`Current Prayer: ${prayerName(prayerTimes.currentPrayer())}\n\n`);
+      // Times population
+      document.getElementById('fajr').textContent = format(prayerTimes.fajr);
+      document.getElementById('sunrise').textContent = format(
+        prayerTimes.sunrise,
+      );
+      document.getElementById('dhuhr').textContent = format(prayerTimes.dhuhr);
+      document.getElementById('asr').textContent = format(prayerTimes.asr);
+      document.getElementById('maghrib').textContent = format(
+        prayerTimes.maghrib,
+      );
+      document.getElementById('isha').textContent = format(prayerTimes.isha);
 
-        document.write(`Qibla Direction: ${adhan.Qibla(coordinates)}`);
+      document.getElementById('midnight').textContent = format(
+        sunnahTimes.middleOfTheNight,
+      );
+      document.getElementById('last-third').textContent = format(
+        sunnahTimes.lastThirdOfTheNight,
+      );
 
-    </script></pre>
+      // Current & Next Prayer Logic
+      const current = prayerTimes.currentPrayer();
+      const next = prayerTimes.nextPrayer();
+      const nextTime = prayerTimes.timeForPrayer(next);
+
+      document.getElementById('current-prayer').textContent = current;
+      document.getElementById('next-prayer').textContent =
+        `${next} @ ${format(nextTime)}`;
+    </script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,13 @@
   "main": "lib/cjs/Adhan.js",
   "module": "lib/esm/Adhan.js",
   "types": "lib/types/Adhan.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/types/Adhan.d.ts",
+      "import": "./lib/esm/Adhan.js",
+      "require": "./lib/cjs/Adhan.js"
+    }
+  },
   "scripts": {
     "clean": "rimraf lib",
     "test": "vitest run",


### PR DESCRIPTION
Example HTML now uses the Temporal API (with polyfill) and the README code snippets have been cleaned up.