### PR TITLE
fix: make the published CommonJS build loadable by Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "coverage": "vitest run --coverage",
     "build": "npm-run-all -l clean -p build:*",
     "build:esm": "cross-env BABEL_ENV=esmUnbundled babel src --extensions '.ts' --out-dir 'lib/esm' --source-maps",
-    "build:cjs": "cross-env BABEL_ENV=cjs babel src --extensions '.ts' --out-dir 'lib/cjs' --source-maps",
+    "build:cjs": "cross-env BABEL_ENV=cjs babel src --extensions '.ts' --out-dir 'lib/cjs' --source-maps && node -e \"require('fs').writeFileSync('lib/cjs/package.json', JSON.stringify({ type: 'commonjs' }) + '\\n')\"",
     "build:bundles": "cross-env BABEL_ENV=esmBundled rollup -c",
     "build:types": "tsc -b tsconfig.types.json",
     "lint": "run-p -l lint:*",


### PR DESCRIPTION
The root `package.json` declares `"type": "module"` and nothing overrides it for `lib/cjs`, so Node parses the CommonJS build as ESM and the `require` condition of the exports map is broken:

```
$ node --input-type=commonjs -e "require('adhan')"
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../lib/cjs/CalculationMethod.js'
```

(the extensionless relative requires Babel emits resolve fine under CJS semantics, but not when the file is force-parsed as ESM). Bundlers paper over it, so browser/React-Native users never notice — but any plain-Node CJS consumer (a build script, a server, a jest transform) hits it.

The standard dual-package fix: the build now writes `lib/cjs/package.json` containing `{ "type": "commonjs" }`, scoping CJS semantics to that directory. Verified after `npm run build`:

```
$ node --input-type=commonjs -e "const a = require('./lib/cjs/Adhan.js'); console.log(Object.keys(a).length)"
12
```

No source changes; suite and lint pass.